### PR TITLE
Removed unused imports from test-cases of two questions

### DIFF
--- a/resources/questions/03057-easy-push/test-cases.tc
+++ b/resources/questions/03057-easy-push/test-cases.tc
@@ -1,5 +1,4 @@
 import type { Equal, Expect } from '@type-challenges/utils'
-import { ExpectFalse, NotEqual } from '@type-challenges/utils'
 
 type cases = [
   Expect<Equal<Push<[], 1>, [1]>>,

--- a/resources/questions/03060-easy-unshift/test-cases.tc
+++ b/resources/questions/03060-easy-unshift/test-cases.tc
@@ -1,5 +1,5 @@
 import type { Equal, Expect } from '@type-challenges/utils'
-import { ExpectFalse, NotEqual } from '@type-challenges/utils'
+
 
 type cases = [
   Expect<Equal<Unshift<[], 1>, [1]>>,


### PR DESCRIPTION
Unused imports were resulting in a warning remaining after the code had been successfully completed ( on questions 3057 and 3060 in the easy section). 