### PR TITLE
fix: tsconfig.default.json is not work in vscode

### DIFF
--- a/resources/tsconfig.json
+++ b/resources/tsconfig.json
@@ -2,10 +2,11 @@
   "compilerOptions": {
     "module": "commonjs",
     "target": "ES2020",
-    "lib": ["ES2020"],
+    "lib": ["ES2020", "DOM"],
     "sourceMap": false,
     "rootDir": "./",
     "strict": true,
-    "noEmit": true
+    "noEmit": true,
+    "noImplicitThis": true
   }
 }

--- a/src/utils/questions.ts
+++ b/src/utils/questions.ts
@@ -7,7 +7,7 @@ import { AuthorMetaInfo, Difficulty, DifficultyMetaInfo, Question, TagMetaInfo }
 import { getWorkspaceFolder } from './settings'
 
 const rootPath = path.join(__dirname, '..', '..', 'resources', 'questions')
-const tsConfigFileName = 'tsconfig.default.json'
+const tsConfigFileName = 'tsconfig.json'
 
 export async function getAllQuestions(): Promise<Question[]> {
   await createTsConfigFile()


### PR DESCRIPTION
- rename `tsconfig.default.json`: vscode recognizes `tsconfig.json` but not `tsconfig.default.json`.
- add lib "DOM" in tsconfig: [00006-hard-simple-vue](https://github.com/type-challenges/type-challenges/tree/main/questions/00006-hard-simple-vue) uses `alert` api located in the DOM.
- add `noImplicitThis` opt in tsconfig: the answer of [00006-hard-simple-vue](https://github.com/type-challenges/type-challenges/tree/main/questions/00006-hard-simple-vue) uses [ThisType](https://www.typescriptlang.org/docs/handbook/utility-types.html#thistypetype) which the [noImplicitThis](https://www.typescriptlang.org/tsconfig#noImplicitThis) flag must be enabled to use.